### PR TITLE
Deploy pages on pull request merges

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
       - develop
+  pull_request:
+    branches:
+      - master
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
Added `pull_request` trigger for `master` and `develop` branches, so as to enable automated GitHub Pages deployment after merges from feature branches.
