### PR TITLE
Correct RTD installation configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,5 @@ formats:
 
 # Optionally declare the Python requirements required to build the docs
 python:
-  requirements: docs/source/requirements.txt
+  install:
+    - requirements: docs/source/requirements.txt


### PR DESCRIPTION
This PR resolves a RTD build failure by correcting the configuration structure for dependency installation. It reverts the incorrect usage of the `python.requirements` key introduced in the preceding PR: 

```yaml
# ...
python:
  requirements: docs/source/requirements.txt
```

This has been reverted to:

```yaml
# ...
python:
  install:
    - requirements: docs/source/requirements.txt
```

The unwanted change from the preceding PR directly resulted in an error: `Invalid configuration key: python.requirements`. 
