### PR TITLE
Standardise HTTP header case

### DIFF
--- a/pyhelpers/ops/web.py
+++ b/pyhelpers/ops/web.py
@@ -413,10 +413,10 @@ def fake_requests_headers(randomized=True, **kwargs):
         >>> from pyhelpers.ops import fake_requests_headers
         >>> fake_headers_1 = fake_requests_headers()
         >>> fake_headers_1
-        {'user-agent': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; it-IT) AppleWebKit/525.1...
+        {'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 5.1; it-IT) AppleWebKit/525.1...
         >>> fake_headers_2 = fake_requests_headers(randomized=False)
         >>> fake_headers_2  # using a random Chrome user-agent string
-        {'user-agent': 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/532.1...
+        {'User-Agent': 'Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/532.1...
 
     .. note::
 
@@ -432,6 +432,6 @@ def fake_requests_headers(randomized=True, **kwargs):
 
     user_agent_string = get_user_agent_string(**kwargs)
 
-    fake_headers = {'user-agent': user_agent_string}
+    fake_headers = {'User-Agent': user_agent_string}
 
     return fake_headers

--- a/tests/test_ops/test_web.py
+++ b/tests/test_ops/test_web.py
@@ -66,7 +66,7 @@ def test_get_user_agent_string(fancy):
 @pytest.mark.parametrize('randomized', [False, True])
 def test_fake_requests_headers(randomized):
     fake_headers_ = fake_requests_headers(randomized=randomized)
-    assert 'user-agent' in fake_headers_
+    assert 'User-Agent' in fake_headers_
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses an issue where the `fake_requests_headers()` function was using the lowercase key. It replaces `'user-agent'` with `'User-Agent'`, ensuring compliance with commonly used HTTP header formatting. 