### PR TITLE
Refactor resource loading

### DIFF
--- a/pyhelpers/__init__.py
+++ b/pyhelpers/__init__.py
@@ -3,12 +3,13 @@ Package initialisation.
 """
 
 import datetime
+import importlib.resources
 import json
-import pkgutil
 
 from . import dbms, dirs, geom, ops, settings, store, text, viz
 
-metadata = json.loads(pkgutil.get_data(__name__, "data/.metadata").decode())
+metadata = json.loads(
+    importlib.resources.files(__name__).joinpath("data/.metadata").read_text(encoding="utf-8"))
 
 __project__ = metadata['Project']
 __pkgname__ = metadata['Package']

--- a/pyhelpers/_cache.py
+++ b/pyhelpers/_cache.py
@@ -800,12 +800,6 @@ def _get_ansi_color_code(colors, show_valid_colors=False, concatenated=True, _sp
     return (final_code, valid_names) if show_valid_colors else final_code
 
 
-_ENGLISH_NUMERALS = json.loads(
-    importlib.resources.files(__name__).joinpath("data/english-numerals.json")
-    .read_text(encoding='utf-8')
-)
-
-
 def _transform_point_type(*pts, as_geom=True):
     """
     Transforms iterable data to geometric type or vice versa.

--- a/pyhelpers/_cache.py
+++ b/pyhelpers/_cache.py
@@ -605,12 +605,6 @@ def _print_failure_message(e, prefix="Error:", verbose=True, raise_error=False):
         raise e
 
 
-_USER_AGENT_STRINGS = json.loads(
-    importlib.resources.files(__name__).joinpath("data/user-agent-strings.json")
-    .read_text(encoding='utf-8')
-)
-
-
 def _init_requests_session(url, max_retries=5, backoff_factor=0.1, retry_status='default',
                            **kwargs):
     # noinspection PyShadowingNames

--- a/pyhelpers/_cache.py
+++ b/pyhelpers/_cache.py
@@ -5,11 +5,10 @@ Cached functions and constants.
 import collections.abc
 import copy
 import functools
-import importlib
+import importlib.resources
 import importlib.util
 import json
 import os
-import pkgutil
 import re
 import shutil
 import sys
@@ -19,9 +18,13 @@ import requests.adapters
 import shapely.geometry
 import urllib3
 
-# import name: (package/module name, install name)
-_OPTIONAL_DEPENDENCY = json.loads(
-    pkgutil.get_data(__name__, "data/optional-dependency.json").decode())
+
+@functools.lru_cache(maxsize=None)
+def _load_package_data(filename):
+    filepath = importlib.resources.files(__name__).joinpath(f"data/{filename}")
+    if filepath.suffix == ".json":  # noqa
+        return json.loads(filepath.read_text(encoding='utf-8'))
+    return {}
 
 
 def _check_dependencies(*names):
@@ -99,13 +102,16 @@ def _check_dependencies(*names):
 
             raise ModuleNotFoundError(
                 f"\n  Possibly the optional dependency '{display_name}' has not been installed.\n"
-                f"\tInstead of `import gdal`, try `import osgeo.gdal` or `from osgeo import gdal`.\n"
+                f"\tTry `import osgeo.gdal` or `from osgeo import gdal`.\n"
                 f"\t  If the error remains, try `pip install {pip_name}` or "
                 f"`pip install <wheel_file>`.")
 
         else:
-            if import_name in _OPTIONAL_DEPENDENCY:
-                display_name, pip_name = _OPTIONAL_DEPENDENCY.get(import_name)
+            optional_dependencies = _load_package_data("optional-dependency.json")
+            # Returns: {import name: (package/module name, install name)}
+
+            if import_name in optional_dependencies:
+                display_name, pip_name = optional_dependencies.get(import_name)
 
             else:
                 display_name = pip_name = import_name.split('.')[0]
@@ -600,7 +606,9 @@ def _print_failure_message(e, prefix="Error:", verbose=True, raise_error=False):
 
 
 _USER_AGENT_STRINGS = json.loads(
-    pkgutil.get_data(__name__, "data/user-agent-strings.json").decode())
+    importlib.resources.files(__name__).joinpath("data/user-agent-strings.json")
+    .read_text(encoding='utf-8')
+)
 
 
 def _init_requests_session(url, max_retries=5, backoff_factor=0.1, retry_status='default',
@@ -717,10 +725,10 @@ def _load_ansi_escape_codes():
     """
 
     try:
-        data = pkgutil.get_data(__name__, "data/ansi-escape-codes.json").decode()
-        raw_data = json.loads(data)
+        filepath = importlib.resources.files(__name__).joinpath("data/ansi-escape-codes.json")
+        raw_data = json.loads(filepath.read_text(encoding='utf-8'))
         return {k: v for k, v in raw_data.items() if not k.startswith('_comment_')}
-    except Exception as e:  # Fallback for e.g. environments where pkgutil may fail
+    except Exception as e:  # Fallback
         print(f"Warning: Could not load data file. Error: {e}")
         return {}
 
@@ -799,7 +807,9 @@ def _get_ansi_color_code(colors, show_valid_colors=False, concatenated=True, _sp
 
 
 _ENGLISH_NUMERALS = json.loads(
-    pkgutil.get_data(__name__, "data/english-numerals.json").decode())
+    importlib.resources.files(__name__).joinpath("data/english-numerals.json")
+    .read_text(encoding='utf-8')
+)
 
 
 def _transform_point_type(*pts, as_geom=True):

--- a/pyhelpers/ops/apis.py
+++ b/pyhelpers/ops/apis.py
@@ -9,8 +9,8 @@ import re
 import secrets
 import string
 
-from .._cache import _add_slashes, _confirmed, _init_requests_session, _print_failure_message, \
-    _USER_AGENT_STRINGS
+from .._cache import _add_slashes, _confirmed, _init_requests_session, _load_package_data, \
+    _print_failure_message
 
 
 class CrossRefOrcid:
@@ -61,10 +61,12 @@ class CrossRefOrcid:
 
         self.my_name = my_name
 
+        user_agent_strings = _load_package_data("user-agent-strings.json")
+
         self.requests_headers = requests_headers or {
             'accept': 'application/json',
             'user-agent': secrets.choice(
-                _USER_AGENT_STRINGS.get(secrets.choice(list(_USER_AGENT_STRINGS)))),
+                user_agent_strings.get(secrets.choice(list(user_agent_strings)))),
         }
 
     def get_orcid_profile(self, orcid_id, section=None, verbose=False):

--- a/pyhelpers/ops/downloads.py
+++ b/pyhelpers/ops/downloads.py
@@ -14,9 +14,8 @@ import urllib.request
 
 import requests.adapters
 
-from .._cache import _add_slashes, _check_dependencies, _check_relative_pathname, \
-    _check_url_scheme, _get_ansi_color_code, _init_requests_session, _print_failure_message, \
-    _USER_AGENT_STRINGS
+from .._cache import _add_slashes, _check_dependencies, _check_relative_pathname, _check_url_scheme, \
+    _get_ansi_color_code, _init_requests_session, _load_package_data, _print_failure_message
 from ..store import _check_saving_path
 
 
@@ -412,9 +411,10 @@ def download_file_from_url(url, path_to_file, if_exists='replace', max_retries=5
         requests_session_args = requests_session_args or {}
         session = _init_requests_session(url=url, max_retries=max_retries, **requests_session_args)
 
+        user_agent_strings = _load_package_data("user-agent-strings.json")
         headers = {
             'user-agent': secrets.choice(
-                _USER_AGENT_STRINGS.get(secrets.choice(list(_USER_AGENT_STRINGS))))}
+                user_agent_strings.get(secrets.choice(list(user_agent_strings))))}
         if requests_headers:
             headers.update(requests_headers)
 
@@ -562,10 +562,11 @@ class GitHubFileDownloader:
         self.total_files = 0
 
         # Set user agent in default
+        user_agent_strings = _load_package_data("user-agent-strings.json")
         opener = urllib.request.build_opener()
         opener.addheaders = [(
             'user-agent',
-            secrets.choice(_USER_AGENT_STRINGS.get(secrets.choice(list(_USER_AGENT_STRINGS)))))]
+            secrets.choice(user_agent_strings.get(secrets.choice(list(user_agent_strings)))))]
 
         urllib.request.install_opener(opener)
 

--- a/pyhelpers/ops/web.py
+++ b/pyhelpers/ops/web.py
@@ -15,7 +15,7 @@ import urllib.parse
 
 import requests
 
-from .._cache import _init_requests_session, _print_failure_message, _USER_AGENT_STRINGS
+from .._cache import _init_requests_session, _load_package_data, _print_failure_message
 
 
 def is_network_connected():
@@ -312,7 +312,7 @@ def load_user_agent_strings(shuffled=False, flattened=False, update=False, verbo
     """
 
     if not update:
-        user_agent_strings = _USER_AGENT_STRINGS.copy()
+        user_agent_strings = _load_package_data("user-agent-strings.json")
 
     else:
         if verbose:

--- a/pyhelpers/text/preprocessing.py
+++ b/pyhelpers/text/preprocessing.py
@@ -9,7 +9,7 @@ import math
 import re
 import string
 
-from .._cache import _check_dependencies, _ENGLISH_NUMERALS, _remove_punctuation, _vectorize_text
+from .._cache import _check_dependencies, _load_package_data, _remove_punctuation, _vectorize_text
 
 
 def clean_html_text(input_text):
@@ -294,23 +294,21 @@ def numeral_english_to_arabic(input_text):
         >>> numeral_english_to_arabic('200 and five')
         205
         >>> numeral_english_to_arabic('Two hundred and fivety')  # Two hundred and fifty
-        Exception: Illegal word: "fivety"
+        ValueError: Illegal word: "fivety"
     """
 
     current = result = 0
 
+    english_numerals = _load_package_data("english-numerals.json")
+
     for word in input_text.lower().replace('-', ' ').split():
-        if word not in _ENGLISH_NUMERALS and not word.isdigit():
-            # word_ = find_similar_str(word, ENGLISH_WRITTEN_NUMBERS)
-            # if word_ is None:
-            raise Exception(f"Illegal word: \"{word}\"")
-            # else:
-            #     word = word_
+        if word not in english_numerals and not word.isdigit():
+            raise ValueError(f'Illegal word: "{word}"')
 
         if word.isdigit():
             scale, increment = (1, int(word))
         else:
-            scale, increment = _ENGLISH_NUMERALS[word]
+            scale, increment = english_numerals.get(word)
         current = current * scale + increment
 
         if scale > 100:

--- a/tests/test_settings/test_preferences.py
+++ b/tests/test_settings/test_preferences.py
@@ -26,6 +26,7 @@ def test_np_preferences(reset):
 @pytest.mark.parametrize('reset', [False, True, 'all'])
 @pytest.mark.parametrize('east_asian_text', [False, True])
 @pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::pandas.errors.Pandas4Warning")
 def test_pd_preferences(reset, east_asian_text):
     pd_preferences(reset=reset, east_asian_text=east_asian_text)
 


### PR DESCRIPTION
This PR replaces `pkgutil` and custom metadata fetching with `importlib.resources`, aligning the codebase with current Python best practices. It also includes necessary test updates for Pandas 3.0 compatibility. 

#### Key changes:

- Replace `pkgutil` with `importlib.resources` for package data access
- Introduce a shared, cached `_load_package_data()` helper
- Lazily load package data previously stored in `_ENGLISH_NUMERALS` and `_USER_AGENT_STRINGS`
- Adjust tests to filter `Pandas4Warning`

These changes are internal refactors only and do not alter public behaviour.

#### Verification:

- Verified that all internal package data (numerals, user agents) load correctly from the source directory.
- Confirmed `pytest` runs without `Pandas4Warning` noise on Pandas 3.0.

Closes #107 
