### PR TITLE
2.3.3.dev3: Fix JSON engine resolution

### DIFF
--- a/pyhelpers/data/.metadata
+++ b/pyhelpers/data/.metadata
@@ -5,7 +5,7 @@
     "Author": "Qian Fu",
     "Affiliation": "University of Birmingham",
     "Email": "q.fu@bham.ac.uk",
-    "Version": "2.3.3.dev1",
+    "Version": "2.3.3.dev3",
     "License": "MIT",
     "First release": "September 2019"
 }

--- a/pyhelpers/store/utils.py
+++ b/pyhelpers/store/utils.py
@@ -3,6 +3,7 @@ Utilities that support the main submodules of :mod:`~pyhelpers.store`.
 """
 
 import functools
+import inspect
 import logging
 import os
 import pathlib
@@ -390,10 +391,16 @@ def _resolve_json_engine(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        # Determine the engine (check kwargs first, then positional args)
-        engine = kwargs.get('engine')
-        if engine is None and len(args) > 1:
-            engine = args[1]  # Assuming engine is the second positional argument
+        # Bind args and kwargs to the function's signature
+        sig = inspect.signature(func)
+        bound_args = sig.bind_partial(*args, **kwargs)
+
+        # Extract 'engine' from bound arguments or get the default value
+        engine = bound_args.arguments.get('engine', sig.parameters['engine'].default)
+
+        # Handle cases where default is inspect.Parameter.empty
+        if engine is inspect.Parameter.empty:
+            engine = None
 
         # Resolve the module
         if engine is not None:
@@ -402,7 +409,7 @@ def _resolve_json_engine(func):
                 raise ValueError(f"`engine` must be one of {valid_engines}")
             kwargs['json_mod'] = _check_dependencies(engine)
         else:
-            kwargs['json_mod'] = sys.modules.get('json')
+            kwargs['json_mod'] = sys.modules.get('json') or __import__('json')
 
         return func(*args, **kwargs)
 

--- a/tests/test_store/test_savers.py
+++ b/tests/test_store/test_savers.py
@@ -122,13 +122,13 @@ def test_save_json(engine, tmp_path, capfd):
 
     dat = {'a': 1, 'b': 2, 'c': 3, 'd': ['a', 'b', 'c']}
 
-    save_json(dat, path_to_file=path_to_file, indent=4, verbose=True)
+    save_json(dat, path_to_file, indent=4, verbose=True)
     out, _ = capfd.readouterr()
     assert f'Saving "{filename}"' in out and "Done." in out
 
     dat = json.loads(example_dataframe().to_json(orient='index'))
 
-    save_json(dat, path_to_file=path_to_file, engine=engine, indent=4, verbose=True)
+    save_json(dat, path_to_file, engine=engine, indent=4, verbose=True)
     out, _ = capfd.readouterr()
     if engine == 'orjson':
         assert all(


### PR DESCRIPTION
This PR rectifies the `_resolve_json_engine` decorator's inability to handle varied positional argument structures.

### Key changes:

- **Logic fix:** Overhauled `_resolve_json_engine` using `inspect.signature`. The decorator now dynamically binds arguments, ensuring engine is correctly identified whether passed positionally or as a keyword, and regardless of its index in the function signature.
- **Test hardening:** Updated `test_save_json()` to use positional arguments for `path_to_file`. This change ensures the engine resolution logic is actually exercised during CI/CD, preventing the "keyword masking" that allowed the previous bug to go undetected.

Fixes #115 