### PR TITLE
Fix submodule resolution in `_LazyModule`

### DIFF
--- a/pyhelpers/_cache.py
+++ b/pyhelpers/_cache.py
@@ -219,7 +219,21 @@ class _LazyModule:
         return self._module
 
     def __getattr__(self, attr):
-        return getattr(self._load(), attr)
+        module = self._load()
+        try:
+            return getattr(module, attr)
+        except AttributeError:
+            # Check if 'attr' is a submodule that needs explicit loading
+            submodule_path = f"{self._name}.{attr}"
+            try:
+                # Attempt to import the subpackage dynamically
+                submodule = importlib.import_module(submodule_path)
+                # Cache the submodule on the parent to avoid repeated imports
+                setattr(module, attr, submodule)
+                return submodule
+            except (ImportError, ModuleNotFoundError):
+                # Re-raise the original error if it's truly not a submodule
+                raise AttributeError(f"module '{self._name}' has no attribute '{attr}'") from None
 
     def __dir__(self):
         return dir(self._load())
@@ -248,6 +262,7 @@ def _lazy_check_dependencies(*args, **kwargs):
         >>> @_lazy_check_dependencies(np='numpy', pd='pandas')  # Aliases
         >>> @_lazy_check_dependencies('scipy', plt='matplotlib.pyplot')  # Mixed
         >>> @_lazy_check_dependencies(**{'sp': 'scipy.sparse'})  # (Alternative)
+        >>> @_lazy_check_dependencies('scipy', 'scipy.sparse')  # Both package and its subpackage
     """
 
     # Build mapping: {'alias': 'package_name'}

--- a/tests/test__cache.py
+++ b/tests/test__cache.py
@@ -59,35 +59,67 @@ def test__check_dependency():
             _check_dependencies('unknown')
 
 
-def test__lazy_check_dependencies():
+def test__lazy_check_dependencies(monkeypatch):
     """
     Test the decorator's ability to inject proxies and load modules on demand.
     """
     from pyhelpers._cache import _lazy_check_dependencies
 
     @_lazy_check_dependencies('numpy', 'pandas')  # No aliases
-    def _test_func_1():
+    def _test_import_numpy_pandas():
         return numpy.__name__ == 'numpy' and pandas.__name__ == 'pandas'  # noqa
 
-    assert _test_func_1()
+    assert _test_import_numpy_pandas()
 
     @_lazy_check_dependencies(np='numpy', pd='pandas')  # Aliases
-    def _test_func_2():
+    def _test_import_np_pd():
         return np.__name__ == 'numpy' and pd.__name__ == 'pandas'  # noqa
 
-    assert _test_func_2()
+    assert _test_import_np_pd()
 
-    @_lazy_check_dependencies('scipy', plt='matplotlib.pyplot')  # Mixed
-    def _test_func_3():
-        return scipy.__name__ == 'scipy' and plt.__name__ == 'matplotlib.pyplot'  # noqa
+    @_lazy_check_dependencies('geopandas', plt='matplotlib.pyplot')  # Mixed
+    def _test_import_geopandas_plt():
+        return geopandas.__name__ == 'geopandas' and plt.__name__ == 'matplotlib.pyplot'  # noqa
 
-    assert _test_func_3()
+    assert _test_import_geopandas_plt()
+
+    @_lazy_check_dependencies('scipy')
+    def _test_import_scipy():
+        return (scipy.__name__ == 'scipy') & (scipy.sparse.__name__ == 'scipy.sparse')  # noqa
+
+    assert _test_import_scipy()
 
     @_lazy_check_dependencies(**{'sp': 'scipy.sparse'})  # (Alternative)
-    def _test_func_4():
+    def _test_import_sp():
         return sp.__name__ == 'scipy.sparse'  # noqa
 
-    assert _test_func_4()
+    assert _test_import_sp()
+
+    # Test actual laziness (Verification that it's not preloading)
+    target_mod = 'pandas'  # or any optional dependency you have
+    # Temporarily remove it from sys.modules for this test only
+    monkeypatch.delitem(sys.modules, target_mod, raising=False)
+
+    @_lazy_check_dependencies(target_mod)
+    def _test_laziness():
+        # Before accessing, it shouldn't be in sys.modules
+        assert target_mod not in sys.modules
+        # Trigger the lazy load
+        name = pandas.__name__  # noqa
+        assert target_mod in sys.modules
+        return name
+
+    assert _test_laziness() == target_mod
+
+    # 7. Test failure mode (AttributeError)
+    @_lazy_check_dependencies('numpy')
+    def _test_invalid_attribute():
+        try:
+            return numpy.this_attribute_does_not_exist  # noqa
+        except AttributeError as e:
+            return str(e)
+
+    assert "has no attribute 'this_attribute_does_not_exist'" in _test_invalid_attribute()
 
 
 def test__confirmed(monkeypatch, capfd):


### PR DESCRIPTION
This PR corrects an `AttributeError` where the `_LazyModule` proxy failed to discover subpackages/submodules (e.g. `folium.plugins`) that are not automatically imported by their parent package.

### Changes:

- Updated `_LazyModule.__getattr__` to intercept `AttributeError` and attempt dynamic submodule import.
- Added caching logic to attach resolved submodules to the parent module, preventing redundant imports.
- Enhanced `_lazy_check_dependencies` tests and docstrings with a test case for submodule resolution.

Fixes #118 