### PR TITLE
fix: skip `None` values for `subdir` arguments in `cd()` 

### DIFF
--- a/pyhelpers/dirs/navigation.py
+++ b/pyhelpers/dirs/navigation.py
@@ -14,7 +14,8 @@ def cd(*subdir, mkdir=False, cwd=None, back_check=False, normalized=True, **kwar
     Specifies the pathname of a directory (or file).
 
     :param subdir: Name of a directory or directories (and/or a filename).
-    :type subdir: str | os.PathLike | bytes
+        ``None`` values are ignored.
+    :type subdir: str | os.PathLike | bytes | None
     :param mkdir: Whether to create the directory; defaults to ``False``.
     :type mkdir: bool
     :param cwd: Current working directory; defaults to ``None``.
@@ -38,6 +39,8 @@ def cd(*subdir, mkdir=False, cwd=None, back_check=False, normalized=True, **kwar
         >>> current_wd = cd()  # Current working directory
         >>> os.path.relpath(current_wd)
         '.'
+        >>> os.path.relpath(cd(None))
+        '.'
         >>> # The directory will be created if it does not exist
         >>> path_to_tests_dir = cd("tests")
         >>> os.path.relpath(path_to_tests_dir)
@@ -60,12 +63,15 @@ def cd(*subdir, mkdir=False, cwd=None, back_check=False, normalized=True, **kwar
         while not os.path.exists(path) and path != os.path.sep:
             path = os.path.dirname(path)
 
-    for x in subdir:
-        x = x.decode() if isinstance(x, bytes) else str(x)
-        if x == "..":
+    for f in subdir:
+        if f is None:
+            continue
+
+        f = f.decode() if isinstance(f, bytes) else str(f)
+        if f == "..":
             path = os.path.dirname(path)
         else:
-            path = os.path.join(path, re.sub(r"[\\/]+", re.escape(os.path.sep), x))
+            path = os.path.join(path, re.sub(r"[\\/]+", re.escape(os.path.sep), f))
 
     if mkdir:
         path_to_file, ext = os.path.splitext(path)

--- a/tests/test_dirs/test_navigation.py
+++ b/tests/test_dirs/test_navigation.py
@@ -5,7 +5,6 @@ Tests the :mod:`~pyhelpers.dirs.navigation` submodule.
 import pathlib
 import shutil
 import sys
-import tempfile
 
 import pytest
 
@@ -14,7 +13,7 @@ from pyhelpers.dirs.validation import is_dir, normalize_pathname
 
 
 @pytest.mark.parametrize('cwd', [None, ".", os.path.join(os.sep, "some_directory")])
-def test_cd(capfd, cwd):
+def test_cd(capfd, cwd, tmp_path):
     current_wd = cd(cwd=cwd, back_check=True, normalized=False)
     if cwd in {None, "."}:
         assert current_wd == os.getcwd()
@@ -25,8 +24,20 @@ def test_cd(capfd, cwd):
         path_to_tests_dir = cd(subdir)
         assert os.path.relpath(path_to_tests_dir).replace(os.sep, "/") == "tests"
 
-    temp = tempfile.TemporaryDirectory()
-    temp_dir = cd(os.path.join(temp.name, 'test_dir'), mkdir=True)
+    # Test that None values in subdir are ignored
+    path_with_none = cd(None)
+    assert path_with_none == normalize_pathname(os.getcwd())
+
+    path_with_none_mixed = cd("test1", None, "test2")
+    expected_path = normalize_pathname(os.path.join(os.getcwd(), "test1", "test2"))
+    assert path_with_none_mixed == expected_path
+
+    path_with_multiple_nones = cd(None, None, "test1", None)
+    expected_path = normalize_pathname(os.path.join(os.getcwd(), "test1"))
+    assert path_with_multiple_nones == expected_path
+
+    # Use tmp_path instead of tempfile.TemporaryDirectory()
+    temp_dir = cd(str(tmp_path / 'test_dir'), mkdir=True)
     assert os.path.isdir(temp_dir)
 
     temp_dir_ = cd(temp_dir, 'test.dir', mkdir=True)
@@ -36,16 +47,12 @@ def test_cd(capfd, cwd):
     init_cwd = cd()
 
     # Change the current working directory
-    new_cwd = os.path.join(".", "tests", "new_cwd")
+    new_cwd = str(tmp_path / "new_cwd")
     os.makedirs(new_cwd, exist_ok=True)
     os.chdir(new_cwd)
 
     path_to_tests = cd("test1")
     assert os.path.relpath(path_to_tests).replace(os.sep, "/") == "test1"
-
-    # Change again the current working directory
-    new_cwd_ = tempfile.TemporaryDirectory()
-    os.chdir(new_cwd_.name)
 
     # Get the full path to a folder named "tests"
     path_to_tests = cd("tests")
@@ -55,7 +62,6 @@ def test_cd(capfd, cwd):
     assert path_to_tests_ == normalize_pathname(os.path.join(os.getcwd(), "test1", "test2"))
 
     os.chdir(init_cwd)  # Restore the initial working directory
-    shutil.rmtree(new_cwd)
 
 
 def test_cdd():


### PR DESCRIPTION
### Summary

Fixes #125 - `cd(None)` now correctly ignores `None` values instead of creating `"/None"` directories.

### Changes

- Skip `None` values in `cd()` subdir arguments using `continue` statement
- Add comprehensive test coverage for None handling in various scenarios:
  - Single `None` value
  - Mixed `None` with valid paths
  - Multiple consecutive `None` values
- Refactored tests to use `tmp_path` fixture for better isolation

### Testing

All tests pass locally. The fix handles edge cases properly without breaking existing functionality.