### PR TITLE
feat(`ops`): add `benchmark_functions` utility

### DIFF
--- a/pyhelpers/ops/general.py
+++ b/pyhelpers/ops/general.py
@@ -284,7 +284,7 @@ def func_running_time(func):
     return inner
 
 
-def benchmark_functions(func_map, test_value, iterations=10_000):
+def benchmark_functions(func_map, test_value, iterations=10_000, verbose=True):
     # noinspection PyShadowingNames,PyUnresolvedReferences
     """
     Compares the execution time of multiple functions using a single test value.
@@ -301,6 +301,8 @@ def benchmark_functions(func_map, test_value, iterations=10_000):
     :type test_value: typing.Any
     :param iterations: Number of times to execute each function. Defaults to ``10_000``.
     :type iterations: int
+    :param verbose: Whether to print results to console. Defaults to ``True``.
+    :type verbose: bool
     :return: A dictionary mapping function names to their total execution time (in seconds).
     :rtype: dict[str, float]
 
@@ -317,6 +319,11 @@ def benchmark_functions(func_map, test_value, iterations=10_000):
         list_comp | 0.201340        | 0.020134
         list_cast | 0.113083        | 0.011308
         {'list_comp': 0.20134030003100634, 'list_cast': 0.11308330000611022}
+
+        >>> # Without console output (just get results)
+        >>> results = benchmark_functions(func_map, test_value=1_000, verbose=False)
+        >>> results
+        {'list_comp': 0.20846570003777742, 'list_cast': 0.10316660004900768}
     """
 
     # Validate inputs
@@ -326,12 +333,15 @@ def benchmark_functions(func_map, test_value, iterations=10_000):
         raise TypeError("All values in `func_map` must be callable")
     if not isinstance(iterations, int) or iterations < 1:
         raise ValueError("`iterations` must be a positive integer")
+    if not isinstance(verbose, bool):
+        raise TypeError("`verbose` must be a boolean")
 
     results = {}
     max_name_len = max((len(name) for name in func_map.keys()), default=10)
 
-    print(f"{'Method':<{max_name_len}} | {'Total Time (s)':<15} | {'Avg Time (ms)':<13}")
-    print("-" * (max_name_len + 42))
+    if verbose:
+        print(f"{'Method':<{max_name_len}} | {'Total Time (s)':<15} | {'Avg Time (ms)':<13}")
+        print("-" * (max_name_len + 42))
 
     for name, func in func_map.items():
         timer = timeit.Timer(lambda f=func: f(test_value))
@@ -340,9 +350,11 @@ def benchmark_functions(func_map, test_value, iterations=10_000):
             execution_time = timer.timeit(number=iterations)
             avg_time_ms = (execution_time / iterations) * 1000
             results[name] = execution_time
-            print(f"{name:<{max_name_len}} | {execution_time:<15.6f} | {avg_time_ms:<13.6f}")
+            if verbose:
+                print(f"{name:<{max_name_len}} | {execution_time:<15.6f} | {avg_time_ms:<13.6f}")
         except Exception as e:
-            print(f"{name:<{max_name_len}} | Failed: {str(e)}")
+            if verbose:
+                print(f"{name:<{max_name_len}} | Failed: {str(e)}")
 
     return results
 

--- a/pyhelpers/ops/general.py
+++ b/pyhelpers/ops/general.py
@@ -9,6 +9,7 @@ import inspect
 import os
 import re
 import subprocess  # nosec
+import timeit
 
 import pandas as pd
 
@@ -281,6 +282,69 @@ def func_running_time(func):
         return res
 
     return inner
+
+
+def benchmark_functions(func_map, test_value, iterations=10_000):
+    # noinspection PyShadowingNames,PyUnresolvedReferences
+    """
+    Compares the execution time of multiple functions using a single test value.
+
+    This function iterates through a mapping of names to callables, times their
+    execution over a specified number of iterations, and prints the results
+    to the console in a formatted table.
+
+    :param func_map: A dictionary where keys are display names and values are the functions
+        to be tested.
+    :type func_map: dict[str, typing.Callable]
+    :param test_value: The input argument to be passed to each function.
+        Should be immutable or not modified by the tested functions.
+    :type test_value: typing.Any
+    :param iterations: Number of times to execute each function. Defaults to ``10_000``.
+    :type iterations: int
+    :return: A dictionary mapping function names to their total execution time (in seconds).
+    :rtype: dict[str, float]
+
+    **Example**::
+
+        >>> from pyhelpers.ops import benchmark_functions
+        >>> func_map = {
+        ...     'list_comp': lambda x: [i for i in range(x)],
+        ...     'list_cast': lambda x: list(range(x))
+        ... }
+        >>> benchmark_functions(func_map, test_value=1_000)
+        Method    | Total Time (s)  | Avg Time (ms)
+        ---------------------------------------------------
+        list_comp | 0.201340        | 0.020134
+        list_cast | 0.113083        | 0.011308
+        {'list_comp': 0.20134030003100634, 'list_cast': 0.11308330000611022}
+    """
+
+    # Validate inputs
+    if not func_map:
+        raise ValueError("`func_map` cannot be empty")
+    if not all(callable(f) for f in func_map.values()):
+        raise TypeError("All values in `func_map` must be callable")
+    if not isinstance(iterations, int) or iterations < 1:
+        raise ValueError("`iterations` must be a positive integer")
+
+    results = {}
+    max_name_len = max((len(name) for name in func_map.keys()), default=10)
+
+    print(f"{'Method':<{max_name_len}} | {'Total Time (s)':<15} | {'Avg Time (ms)':<13}")
+    print("-" * (max_name_len + 42))
+
+    for name, func in func_map.items():
+        timer = timeit.Timer(lambda f=func: f(test_value))
+
+        try:
+            execution_time = timer.timeit(number=iterations)
+            avg_time_ms = (execution_time / iterations) * 1000
+            results[name] = execution_time
+            print(f"{name:<{max_name_len}} | {execution_time:<15.6f} | {avg_time_ms:<13.6f}")
+        except Exception as e:
+            print(f"{name:<{max_name_len}} | Failed: {str(e)}")
+
+    return results
 
 
 def get_git_branch(verbose=False):

--- a/tests/test_ops/test_general.py
+++ b/tests/test_ops/test_general.py
@@ -2,12 +2,16 @@
 Tests the :mod:`~pyhelpers.ops.general` submodule.
 """
 
+import os
 import time
 
+import pandas as pd
 import pytest
 
 from pyhelpers.dbms import PostgreSQL
-from pyhelpers.ops.general import *
+from pyhelpers.ops.general import benchmark_functions, confirmed, func_running_time, \
+    get_ansi_color_code, get_git_branch, get_obj_attr, get_project_structure, hash_password, \
+    verify_password
 
 
 def test_confirmed(monkeypatch):
@@ -76,6 +80,73 @@ def test_func_running_time(capfd):
     test_func()
     out, _ = capfd.readouterr()
     assert "INFO Finished running function: test_func, total: 3s" in out
+
+
+def test_benchmark_functions(capfd):
+    """
+    Test the benchmark_functions utility with valid inputs, error handling, and exceptions.
+    """
+
+    # Test 1: Normal operation with valid functions
+    func_map = {
+        'list_comp': lambda x: [i for i in range(x)],
+        'list_cast': lambda x: list(range(x))
+    }
+
+    results = benchmark_functions(func_map, test_value=100, iterations=100)
+
+    # Verify results structure
+    assert isinstance(results, dict)
+    assert len(results) == 2
+    assert 'list_comp' in results
+    assert 'list_cast' in results
+
+    # Verify timing values are positive floats
+    for name, timing in results.items():
+        assert isinstance(timing, float)
+        assert timing > 0
+
+    # Verify printed output
+    captured = capfd.readouterr()
+    assert 'Method' in captured.out
+    assert 'Total Time (s)' in captured.out
+    assert 'Avg Time (ms)' in captured.out
+    assert 'list_comp' in captured.out
+    assert 'list_cast' in captured.out
+
+    # Test 2: Error handling - empty func_map
+    with pytest.raises(ValueError, match="`func_map` cannot be empty"):
+        benchmark_functions({}, test_value=10)
+
+    # Test 3: Error handling - non-callable values
+    with pytest.raises(TypeError, match="All values in `func_map` must be callable"):
+        benchmark_functions({'test': 'not_callable'}, test_value=10)  # noqa
+
+    # Test 4: Error handling - invalid iterations
+    with pytest.raises(ValueError, match="`iterations` must be a positive integer"):
+        benchmark_functions({'test': lambda x: x}, test_value=10, iterations=0)
+
+    with pytest.raises(ValueError, match="`iterations` must be a positive integer"):
+        benchmark_functions({'test': lambda x: x}, test_value=10, iterations=-1)
+
+    # Test 5: Exception handling in benchmarked functions
+    func_map_with_error = {
+        'valid': lambda x: x * 2,
+        'raises_error': lambda x: 1 / 0  # ZeroDivisionError
+    }
+
+    results_partial = benchmark_functions(func_map_with_error, test_value=10, iterations=10)
+
+    # Valid function should be in results
+    assert 'valid' in results_partial
+    assert isinstance(results_partial['valid'], float)
+
+    # Failed function should not be in results
+    assert 'raises_error' not in results_partial
+
+    # Check error message was printed
+    captured = capfd.readouterr()
+    assert 'Failed' in captured.out
 
 
 def test_get_git_branch(capfd):

--- a/tests/test_ops/test_general.py
+++ b/tests/test_ops/test_general.py
@@ -87,13 +87,13 @@ def test_benchmark_functions(capfd):
     Test the benchmark_functions utility with valid inputs, error handling, and exceptions.
     """
 
-    # Test 1: Normal operation with valid functions
+    # Test 1: Normal operation with verbose=True
     func_map = {
         'list_comp': lambda x: [i for i in range(x)],
         'list_cast': lambda x: list(range(x))
     }
 
-    results = benchmark_functions(func_map, test_value=100, iterations=100)
+    results = benchmark_functions(func_map, test_value=100, iterations=100, verbose=True)
 
     # Verify results structure
     assert isinstance(results, dict)
@@ -114,28 +114,32 @@ def test_benchmark_functions(capfd):
     assert 'list_comp' in captured.out
     assert 'list_cast' in captured.out
 
-    # Test 2: Error handling - empty func_map
+    # Test 2: With verbose=False (no output)
+    results_silent = benchmark_functions(func_map, test_value=100, iterations=100, verbose=False)
+    captured = capfd.readouterr()
+    assert captured.out == ""  # No output when verbose=False
+    assert results_silent.keys() == results.keys()  # Results should be the same
+
+    # Test 3: Error handling - empty func_map
     with pytest.raises(ValueError, match="`func_map` cannot be empty"):
         benchmark_functions({}, test_value=10)
 
-    # Test 3: Error handling - non-callable values
+    # Test 4: Error handling - non-callable values
     with pytest.raises(TypeError, match="All values in `func_map` must be callable"):
         benchmark_functions({'test': 'not_callable'}, test_value=10)  # noqa
 
-    # Test 4: Error handling - invalid iterations
+    # Test 5: Error handling - invalid iterations
     with pytest.raises(ValueError, match="`iterations` must be a positive integer"):
         benchmark_functions({'test': lambda x: x}, test_value=10, iterations=0)
 
     with pytest.raises(ValueError, match="`iterations` must be a positive integer"):
         benchmark_functions({'test': lambda x: x}, test_value=10, iterations=-1)
 
-    # Test 5: Exception handling in benchmarked functions
-    func_map_with_error = {
-        'valid': lambda x: x * 2,
-        'raises_error': lambda x: 1 / 0  # ZeroDivisionError
-    }
+    # Test 6: Exception handling in benchmarked functions with verbose output
+    func_map_with_error = {'valid': lambda x: x * 2, 'raises_error': lambda x: 1 / 0}
 
-    results_partial = benchmark_functions(func_map_with_error, test_value=10, iterations=10)
+    results_partial = benchmark_functions(
+        func_map_with_error, test_value=10, iterations=10, verbose=True)
 
     # Valid function should be in results
     assert 'valid' in results_partial


### PR DESCRIPTION
### Summary

Adds a new benchmarking utility to `general.py` for comparing function execution performance.

### Changes

* **Features**: Added `benchmark_functions()` to calculate and compare execution times for a mapping of callables using `timeit`.
* **Testing**: Added comprehensive unit tests in the `ops` suite to verify function mapping and edge case handling.
