### PR TITLE
fix: update GitHub Pages workflow to Python 3.12

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
### Summary:

This PR resolves the dependency resolution error in the documentation build pipeline.

### Changes:

Updated `python-version` from `'3.11'` to `'3.12'` in `.github/workflows/github-pages.yml`.

### Context:

Sphinx version 9.1.0 introduced a breaking change for older environments by requiring Python >= 3.12. Our previous CI configuration was pinned to 3.11, causing the `Install dependencies` step to fail with:
`ERROR: No matching distribution found for Sphinx==9.1.0`.

### Related Issue:

Fixes #131 