### PR TITLE
Skip byte-count validation for compressed downloads

### DIFF
--- a/pyhelpers/ops/downloads.py
+++ b/pyhelpers/ops/downloads.py
@@ -160,7 +160,18 @@ def _prep_pbar_args(response, path_to_file, total_records=None, chunk_multiplier
     return file_size, chunk_size, total_rec, pbar_args, pbar_indent
 
 
-def _validate_downloaded_file(validate, file_size, written, total_rec, actual_records, indent):
+def _has_compressed_content_encoding(response):
+    """
+    Whether ``requests`` may yield decoded bytes for a compressed response body.
+    """
+
+    content_encoding = response.headers.get('Content-Encoding', '').lower()
+    encodings = (x.strip() for x in content_encoding.split(','))
+    return any(x in {'br', 'deflate', 'gzip'} for x in encodings)
+
+
+def _validate_downloaded_file(validate, file_size, written, total_rec, actual_records, indent,
+                              skip_byte_count=False):
     """
     Validate the integrity of the downloaded file against expected metrics.
 
@@ -176,6 +187,8 @@ def _validate_downloaded_file(validate, file_size, written, total_rec, actual_re
     :type actual_records: int
     :param indent: Formatted indentation string for messages.
     :type indent: str
+    :param skip_byte_count: Whether to skip strict byte-count matching.
+    :type skip_byte_count: bool
     :raises ValueError: If byte counts do not match when ``file_size > 0``.
     """
 
@@ -184,7 +197,10 @@ def _validate_downloaded_file(validate, file_size, written, total_rec, actual_re
         return
 
     if file_size > 0:
-        if written != file_size:
+        if skip_byte_count:
+            print(f"Done.\n"
+                  f"{indent}(Byte-count validation skipped for compressed response content.)")
+        elif written != file_size:
             print("Failed.")
             raise ValueError(
                 f"Byte count mismatch. Expected {file_size} bytes, but received {written} bytes.")
@@ -387,7 +403,8 @@ def _download_file_from_url(response, path_to_file, total_records=None, chunk_mu
 
         _validate_downloaded_file(
             validate=validate, file_size=file_size, written=written,
-            total_rec=total_rec, actual_records=actual_records, indent=validate_indent
+            total_rec=total_rec, actual_records=actual_records, indent=validate_indent,
+            skip_byte_count=_has_compressed_content_encoding(response)
         )
 
     except Exception as e:

--- a/tests/test_ops/test_downloads.py
+++ b/tests/test_ops/test_downloads.py
@@ -53,6 +53,21 @@ def test__download_file_from_url(total_records, validate, content_length, tmp_pa
                     assert "Warning" in out and "validation skipped" not in out
 
 
+def test__download_file_from_url_with_compressed_content_encoding(tmp_path, capfd):
+    path_to_file = tmp_path / "test.txt"
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.headers = {'Content-Length': 1, 'Content-Encoding': 'gzip'}
+    mock_response.url = 'http://test_download_file_from_url.com/test.txt'
+    mock_response.iter_content = Mock(return_value=[b'col1,col2\nval1,val2\n'])
+
+    _download_file_from_url(mock_response, path_to_file, disable=True)
+
+    out, _ = capfd.readouterr()
+    assert "Byte-count validation skipped" in out
+    assert path_to_file.read_bytes() == b'col1,col2\nval1,val2\n'
+
+
 @pytest.mark.parametrize('verbose', [True, False])
 @pytest.mark.parametrize('stream_download', [True, False])
 def test_download_file_from_url(verbose, stream_download, tmp_path, capfd):


### PR DESCRIPTION
## Summary
- Skip strict Content-Length byte-count validation when a response uses compressed Content-Encoding
- Keep record-count validation unchanged
- Add a mocked regression test for compressed responses whose decoded body is larger than the compressed Content-Length

Fixes #136.

## Tests
- .venv/bin/python -m pytest tests/test_ops/test_downloads.py -q
- .venv/bin/python -m compileall -q pyhelpers/ops/downloads.py tests/test_ops/test_downloads.py
