### PR TITLE
chore(release): bump version to 2.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyhelpers"
-version = "2.5.1rc1"
+version = "2.5.1"
 description = "An open-source toolkit for facilitating Python users' data manipulation tasks"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2348,7 +2348,7 @@ wheels = [
 
 [[package]]
 name = "pyhelpers"
-version = "2.5.1rc1"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
### Summary

This PR prepares `pyhelpers` for its official stable release by updating the project version from `2.5.1rc1` to `2.5.1` across package metadata and environment lockfiles.


### Key Changes

- **Version bump:** Updated `version` in `pyproject.toml` from `2.5.1rc1` to `2.5.1`.
- **Lockfile synchronisation:** Synchronised `uv.lock` via `uv sync` to ensure complete alignment with project metadata.


### Verification

- Executed `uv sync --all-extras --all-groups` to verify lockfile integrity.
- Validated package metadata and built distribution artefacts locally using `uv build`.