### PR TITLE
refactor(settings): defer packaging.version import

### DIFF
--- a/pyhelpers/settings/preferences.py
+++ b/pyhelpers/settings/preferences.py
@@ -5,8 +5,6 @@ Preferences.
 import copy
 import os
 
-import packaging.version
-
 from .._cache import _check_dependencies
 
 
@@ -148,6 +146,8 @@ def pd_preferences(reset=False, max_columns=100, min_rows=10, max_rows=40, preci
             pd.set_option(key, registered_options[key].defval)
 
     elif reset == 'all':
+        import packaging.version
+
         if packaging.version.parse(pd.__version__) >= packaging.version.parse("3.0.0"):
             pd.reset_option('all')
         else:


### PR DESCRIPTION
### Summary

This PR refactors `pyhelpers/settings/preferences.py` to lazy-load `packaging.version` inside `pd_preferences`, improving module initialisation time when importing `pyhelpers.settings`.


### Key Changes

- **Lazy import:** Relocated `import packaging.version` from top-level module execution to within the `pd_preferences` function body.
- **Performance optimisation:** Avoids loading the `packaging` module during initial package setup when `pd_preferences` is not explicitly called.


#### Verification

- Executed `pytest tests/test_settings.py` to confirm `pd_preferences` continues to resolve pandas version checks correctly.
- Confirmed no breaking changes to public API signatures or module exports.